### PR TITLE
fix: skip heartbeat ping during active file transfer

### DIFF
--- a/app/app/src/main/java/com/sourav/litsync/LitSyncState.kt
+++ b/app/app/src/main/java/com/sourav/litsync/LitSyncState.kt
@@ -10,4 +10,6 @@ object LitSyncState {
 
     // list to keep track of files currently being downloaded so watcher ignore them
     val filesBeingReceived: MutableSet<String> = Collections.synchronizedSet(mutableSetOf())
+
+    val isTransferring = java.util.concurrent.atomic.AtomicBoolean(false)
 }

--- a/app/app/src/main/java/com/sourav/litsync/SyncService.kt
+++ b/app/app/src/main/java/com/sourav/litsync/SyncService.kt
@@ -91,6 +91,10 @@ class SyncService : Service() {
                 val heartbeatJob = launch {
                     while (isActive) {
                         kotlinx.coroutines.delay(3000)  // ping every 3 seconds
+                        if (LitSyncState.isTransferring.get()) {
+                            println("[SyncService] Transfer in progress, skipping hearbeat ping.")
+                            continue
+                        }
                         val isAlive = NetworkManager().sendPing(currentIp, currentPort)
                         if (!isAlive) {
                             println("[SyncService] Heartbeat lost! Tripping wire...")
@@ -103,6 +107,7 @@ class SyncService : Service() {
                 // start watching for file changes
                 activeWatcher = Watcher(folderPath) { action, file ->
                     serviceScope.launch {
+                        LitSyncState.isTransferring.set(true)
                         val success = if (action == "UPLOAD") {
                             NetworkManager().sendFile(file, currentIp, currentPort)
                         } else if (action == "DELETE") {
@@ -110,6 +115,7 @@ class SyncService : Service() {
                         } else {
                             true
                         }
+                        LitSyncState.isTransferring.set(false)
 
                         if(!success){
                             println("[SyncService] Network request failed! Tripping wire...")


### PR DESCRIPTION
Add isTransferring AtomicBoolean to LitSyncState.
Watcher callback sets flag around network calls.
Heartbeat coroutine skips ping if transfer is in progress.

Closes #9