### PR TITLE
fix: atomic tmp-rename pattern for incoming file transfers

### DIFF
--- a/app/app/src/main/java/com/sourav/litsync/ServerManager.kt
+++ b/app/app/src/main/java/com/sourav/litsync/ServerManager.kt
@@ -57,11 +57,15 @@ class ServerManager(private val folderPath: String) {
                             // tell watcher to ignore this file
                             LitSyncState.filesBeingReceived.add(fileName)
 
+                            val tmpFile = File(folderPath, "$fileName.tmp")
+
+                            var totalRead = 0L
+                            var transferComplete = false
+
                             // stream raw file bytes directly to android hard drive
-                            FileOutputStream(targetFile).use{ fos ->
+                            FileOutputStream(tmpFile).use{ fos ->
                                 val buffer = ByteArray(4096)
                                 var bytesRead: Int
-                                var totalRead = 0L
 
                                 while(totalRead < size){
                                     // only read exactly what we need so we don't block forever
@@ -72,11 +76,22 @@ class ServerManager(private val folderPath: String) {
                                     fos.write(buffer, 0, bytesRead)
                                     totalRead += bytesRead
                                 }
+
+                                transferComplete = totalRead >= size
+                            }
+
+                            if(transferComplete){
+                                // atomic: tmp -> real name
+                                tmpFile.renameTo(targetFile)
+                                println("[ServerManager] Successfully saved linux push: $fileName")
+                            } else {
+                                // partial transfer: discard silently
+                                tmpFile.delete()
+                                println("[ServerManager] Incomplete transfer, discarded: $fileName")
                             }
 
                             // file saved. unignore now
                             LitSyncState.filesBeingReceived.remove(fileName)
-                            println("[ServerManager] Successfully saved linux push: $fileName")
                         }
 
                         "DELETE" -> {

--- a/daemon/src/network.cpp
+++ b/daemon/src/network.cpp
@@ -157,7 +157,9 @@ void NetworkManager::listenForConnections(SyncManager& syncManager, const std::s
 
                     // path where the file will be saved
                     std::string filepath = sync_folder + "/" + cmd.filename;
-                    std::ofstream outfile(filepath, std::ios::binary);
+                    std::string tmp_path = filepath + ".tmp";  // write in tmp file first
+                    
+                    std::ofstream outfile(tmp_path, std::ios::binary);
 
                     if(outfile.is_open()){
                         size_t total_received = 0;
@@ -195,11 +197,20 @@ void NetworkManager::listenForConnections(SyncManager& syncManager, const std::s
                         }
 
                         std::cout << std::endl; // lock in the finished progress bar
-                        std::cout << "[Watcher] Successfully saved: " << cmd.filename << std::endl;
-
                         outfile.close();
+
+                        // only rename to real name if got complete data
+                        if(total_received >= cmd.filesize){
+                            std::filesystem::rename(tmp_path, filepath);
+                            std::cout << "[Watcher] Successfully saved: " << cmd.filename << std::endl;
+                        } else {
+                            // partial transfer: delete the .tmp and give log on terminal
+                            std::filesystem::remove(tmp_path);
+                            std::cerr << "[Network] Incomplete transfer, discarded: " << cmd.filename << std::endl;
+                        }
+
                     } else {
-                        std::cerr << "[Netowork] Error: Could not open file for writing: " << filepath << std::endl;
+                        std::cerr << "[Netowork] Error: Could not open tmp file for writing: " << tmp_path << std::endl;
                     }
                 }
 


### PR DESCRIPTION
## Problem
If WiFi disconnects mid-transfer, an incomplete file was left on 
disk with the real filename. Silent corruption with no cleanup.

## Fix
Write incoming data to `filename.tmp` first. Rename to the real 
filename only after the full transfer completes. Discard `.tmp` 
if transfer is incomplete.

Applies to both sides:
- `daemon/src/network.cpp` — Linux receiving files from Android
- `ServerManager.kt` — Android receiving files from Linux

Closes #8